### PR TITLE
Update dfl-feature-ids.rst

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -122,6 +122,10 @@ document.
      - 0
      - 0x24
 
+   * - Scalable Scatter-Gather DMA Intel FPGA IP 
+     - 0
+     - 0x25
+
    * - Port Errors
      - 1
      - 0x10


### PR DESCRIPTION
to add DFH feature ID for Scalable Scatter-Gather DMA Intel FPGA IP