### PR TITLE
Add child AFU feature ID and AFU parameter ID list

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -18,6 +18,10 @@ document.
      - Feature Type
      - Feature ID
 
+   * - **FIM**
+     - **0**
+     -
+
    * - Thermal Mgmt (legacy)
      - 0
      - 1
@@ -130,6 +134,18 @@ document.
      - 0
      - 0x26
 
+   * - **AFU**
+     - **1**
+     -
+
+   * - Normal AFU
+     - 1
+     - 0
+
+   * - Child port of a multi-ported AFU
+     - 1
+     - 1
+
    * - Port Errors
      - 1
      - 0x10
@@ -149,3 +165,7 @@ document.
    * - s10 IOPLL
      - 1
      - 0x14
+
+   * - **BBB (Basic Building Block)**
+     - **2**
+     -

--- a/dfl-param-ids.rst
+++ b/dfl-param-ids.rst
@@ -1,0 +1,32 @@
+.. SPDX-License-Identifier: GPL-2.0
+
+========================================
+Device Feature List (DFL) Parameter Ids
+========================================
+
+Parameter IDs within a version 1 feature are often private to a particular
+feature GUID. The first feature in an AFU at the AFU's MMIO offset 0 has a
+unique problem: the GUID of the feature is the AFU's GUID. When an AFU feature
+parameter must be interpreted by the system, globally defined parameter IDs
+are needed. The following parameter IDs are valid for any AFU feature and
+should not be used for other meanings within an AFU:
+
+.. list-table:: AFU First Feature Parameter IDs
+   :widths: 2 2 2
+   :header-rows: 1
+
+   * - Parameter Name
+     - ID
+     - Version
+
+   * - MSI-X
+     - 1
+     - 0
+
+   * - Child AFU GUID list
+     - 2
+     - 0
+
+   * - Reserved
+     - 3 - 0xff
+     -


### PR DESCRIPTION
A child is a part of a multi-ported AFU. One parent AFU on a different port points to the child.