### PR TITLE
dfl-feature-ids.rst: Add EMIF User Clock IP

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -134,6 +134,10 @@ document.
      - 0
      - 0x26
 
+   * - EMIF User Clock IP for Agilex 7 M-Series
+     - 0
+     - 0x27
+
    * - **AFU**
      - **1**
      -


### PR DESCRIPTION
Added a new feature ID for an IP that we (IBEX Technology) have implemented.

This is an IP inside FIM to support AFU user clock feature on M-Series devices with EMIF Calibration IP.
Actual implementation is yet to be released open-source, but we want to reserve the ID now.
